### PR TITLE
Add loading skeleton for compact view type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -48,21 +48,21 @@ class PostListAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
+        val loadingType = when (itemLayoutType) {
+            STANDARD -> VIEW_TYPE_LOADING
+            COMPACT -> VIEW_TYPE_LOADING_COMPACT
+        }
+
         return when (getItem(position)) {
             is EndListIndicatorItem -> VIEW_TYPE_ENDLIST_INDICATOR
-            is LoadingItem -> VIEW_TYPE_LOADING
+            is LoadingItem -> loadingType
             is PostListItemUiState -> {
                 return when (itemLayoutType) {
                     STANDARD -> VIEW_TYPE_POST
                     COMPACT -> VIEW_TYPE_POST_COMPACT
                 }
             }
-            null -> {
-                return when (itemLayoutType) {
-                    STANDARD -> VIEW_TYPE_LOADING
-                    COMPACT -> VIEW_TYPE_LOADING_COMPACT
-                }
-            }
+            null -> loadingType
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -26,6 +26,7 @@ private const val VIEW_TYPE_POST = 0
 private const val VIEW_TYPE_POST_COMPACT = 1
 private const val VIEW_TYPE_ENDLIST_INDICATOR = 2
 private const val VIEW_TYPE_LOADING = 3
+private const val VIEW_TYPE_LOADING_COMPACT = 4
 
 class PostListAdapter(
     context: Context,
@@ -56,7 +57,12 @@ class PostListAdapter(
                     COMPACT -> VIEW_TYPE_POST_COMPACT
                 }
             }
-            null -> VIEW_TYPE_LOADING // Placeholder by paged list
+            null -> {
+                return when (itemLayoutType) {
+                    STANDARD -> VIEW_TYPE_LOADING
+                    COMPACT -> VIEW_TYPE_LOADING_COMPACT
+                }
+            }
         }
     }
 
@@ -69,6 +75,10 @@ class PostListAdapter(
             }
             VIEW_TYPE_LOADING -> {
                 val view = layoutInflater.inflate(R.layout.post_list_item_skeleton, parent, false)
+                LoadingViewHolder(view)
+            }
+            VIEW_TYPE_LOADING_COMPACT -> {
+                val view = layoutInflater.inflate(R.layout.post_list_item_compact_skeleton, parent, false)
                 LoadingViewHolder(view)
             }
             VIEW_TYPE_POST -> {

--- a/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
@@ -43,7 +43,6 @@
             android:layout_centerVertical="true"
             android:layout_marginEnd="@dimen/margin_large"
             android:layout_marginStart="@dimen/margin_small"
-            android:background="?selectableItemBackground"
             android:contentDescription="@string/more"
             android:src="@drawable/ic_ellipsis_vertical_white_24dp"
             android:tint="@color/neutral_600"/>

--- a/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
@@ -13,7 +13,7 @@
         <View
             android:id="@+id/title"
             android:layout_width="match_parent"
-            android:layout_height="20dp"
+            android:layout_height="@dimen/post_list_row_skeleton_view_title_height"
             android:layout_alignParentStart="true"
             android:layout_marginEnd="@dimen/margin_extra_large"
             android:layout_marginStart="@dimen/margin_extra_large"
@@ -25,11 +25,11 @@
         <View
             android:id="@+id/date"
             android:layout_width="match_parent"
-            android:layout_height="20dp"
+            android:layout_height="@dimen/post_list_row_skeleton_view_date_height"
             android:layout_alignParentStart="true"
             android:layout_below="@+id/title"
-            android:layout_marginBottom="6dp"
-            android:layout_marginEnd="40dp"
+            android:layout_marginBottom="@dimen/margin_small"
+            android:layout_marginEnd="@dimen/margin_extra_extra_extra_large"
             android:layout_marginStart="@dimen/margin_extra_large"
             android:layout_marginTop="@dimen/margin_medium"
             android:layout_toStartOf="@+id/more_button"

--- a/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.shimmer.ShimmerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                         xmlns:app="http://schemas.android.com/apk/res-auto"
+                                         xmlns:tools="http://schemas.android.com/tools"
+                                         android:layout_width="match_parent"
+                                         android:layout_height="@dimen/posts_list_compact_row_height">
+    <RelativeLayout
+        android:id="@+id/background"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/posts_list_compact_row_height"
+        android:background="@color/white">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?selectableItemBackground">
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_large"
+                android:layout_toStartOf="@+id/image_featured"
+                android:ellipsize="end"
+                android:fontFamily="serif"
+                android:maxLines="1"
+                android:textAlignment="textStart"
+                android:textColor="@color/neutral_800"
+                android:textSize="@dimen/text_sz_large"
+                android:textStyle="bold"
+                app:layout_goneMarginTop="@dimen/margin_extra_large"
+                tools:text="Testing title Testing title Testing title Testing title Testing title Testing title Testing title Testing title"/>
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/title"
+                android:layout_marginBottom="6dp"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:ellipsize="end"
+                android:fontFamily="serif"
+                android:maxLines="1"
+                android:textColor="@color/neutral_500"
+                android:textSize="@dimen/text_sz_medium"
+                tools:text="99 days ago"/>
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/statuses_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/title"
+                android:layout_marginEnd="@dimen/margin_medium"
+                android:layout_marginStart="@dimen/margin_medium"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:layout_toEndOf="@+id/date"
+                android:layout_toStartOf="@+id/image_featured"
+                android:ellipsize="end"
+                android:fontFamily="serif"
+                android:maxLines="1"
+                android:textAlignment="textStart"
+                android:textColor="@color/warning_500"
+                app:layout_goneMarginBottom="@dimen/margin_extra_large"
+                tools:text="Private · Local Changes"/>
+
+
+            <ImageView
+                android:id="@+id/image_featured"
+                android:layout_width="@dimen/posts_list_compact_image_size"
+                android:layout_height="@dimen/posts_list_compact_image_size"
+                android:layout_centerVertical="true"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_small"
+                android:layout_marginStart="@dimen/margin_small"
+                android:layout_marginTop="@dimen/margin_large"
+                android:layout_toStartOf="@+id/more_button"
+                android:background="@color/red_0"
+                android:contentDescription="@string/featured_image_desc"
+                android:visibility="gone"/>
+
+            <ImageButton
+                android:id="@+id/more_button"
+                android:layout_width="@dimen/posts_list_compact_menu_button_size"
+                android:layout_height="@dimen/posts_list_compact_menu_button_size"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_small"
+                android:contentDescription="@string/more"
+                android:src="@drawable/ic_ellipsis_vertical_white_24dp"
+                android:tint="@color/neutral_600"
+                android:background="?selectableItemBackground"/>
+
+        </RelativeLayout>
+
+    </RelativeLayout>
+</com.facebook.shimmer.ShimmerFrameLayout>

--- a/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
+++ b/WordPress/src/main/res/layout/post_list_item_compact_skeleton.xml
@@ -1,102 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.facebook.shimmer.ShimmerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                          xmlns:app="http://schemas.android.com/apk/res-auto"
-                                         xmlns:tools="http://schemas.android.com/tools"
                                          android:layout_width="match_parent"
                                          android:layout_height="@dimen/posts_list_compact_row_height">
+
     <RelativeLayout
         android:id="@+id/background"
         android:layout_width="match_parent"
         android:layout_height="@dimen/posts_list_compact_row_height"
         android:background="@color/white">
 
-        <RelativeLayout
+        <View
+            android:id="@+id/title"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="?selectableItemBackground">
+            android:layout_height="20dp"
+            android:layout_alignParentStart="true"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_large"
+            android:layout_toStartOf="@+id/more_button"
+            android:background="@color/neutral_50"
+            app:layout_goneMarginTop="@dimen/margin_extra_large"/>
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginEnd="@dimen/margin_extra_large"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_large"
-                android:layout_toStartOf="@+id/image_featured"
-                android:ellipsize="end"
-                android:fontFamily="serif"
-                android:maxLines="1"
-                android:textAlignment="textStart"
-                android:textColor="@color/neutral_800"
-                android:textSize="@dimen/text_sz_large"
-                android:textStyle="bold"
-                app:layout_goneMarginTop="@dimen/margin_extra_large"
-                tools:text="Testing title Testing title Testing title Testing title Testing title Testing title Testing title Testing title"/>
+        <View
+            android:id="@+id/date"
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/title"
+            android:layout_marginBottom="6dp"
+            android:layout_marginEnd="40dp"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_toStartOf="@+id/more_button"
+            android:background="@color/neutral_50"/>
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_below="@+id/title"
-                android:layout_marginBottom="6dp"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:ellipsize="end"
-                android:fontFamily="serif"
-                android:maxLines="1"
-                android:textColor="@color/neutral_500"
-                android:textSize="@dimen/text_sz_medium"
-                tools:text="99 days ago"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/statuses_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/title"
-                android:layout_marginEnd="@dimen/margin_medium"
-                android:layout_marginStart="@dimen/margin_medium"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:layout_toEndOf="@+id/date"
-                android:layout_toStartOf="@+id/image_featured"
-                android:ellipsize="end"
-                android:fontFamily="serif"
-                android:maxLines="1"
-                android:textAlignment="textStart"
-                android:textColor="@color/warning_500"
-                app:layout_goneMarginBottom="@dimen/margin_extra_large"
-                tools:text="Private · Local Changes"/>
-
-
-            <ImageView
-                android:id="@+id/image_featured"
-                android:layout_width="@dimen/posts_list_compact_image_size"
-                android:layout_height="@dimen/posts_list_compact_image_size"
-                android:layout_centerVertical="true"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:layout_marginEnd="@dimen/margin_small"
-                android:layout_marginStart="@dimen/margin_small"
-                android:layout_marginTop="@dimen/margin_large"
-                android:layout_toStartOf="@+id/more_button"
-                android:background="@color/red_0"
-                android:contentDescription="@string/featured_image_desc"
-                android:visibility="gone"/>
-
-            <ImageButton
-                android:id="@+id/more_button"
-                android:layout_width="@dimen/posts_list_compact_menu_button_size"
-                android:layout_height="@dimen/posts_list_compact_menu_button_size"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:layout_marginEnd="@dimen/margin_large"
-                android:layout_marginStart="@dimen/margin_small"
-                android:contentDescription="@string/more"
-                android:src="@drawable/ic_ellipsis_vertical_white_24dp"
-                android:tint="@color/neutral_600"
-                android:background="?selectableItemBackground"/>
-
-        </RelativeLayout>
+        <ImageButton
+            android:id="@+id/more_button"
+            android:layout_width="@dimen/posts_list_compact_menu_button_size"
+            android:layout_height="@dimen/posts_list_compact_menu_button_size"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/margin_large"
+            android:layout_marginStart="@dimen/margin_small"
+            android:background="?selectableItemBackground"
+            android:contentDescription="@string/more"
+            android:src="@drawable/ic_ellipsis_vertical_white_24dp"
+            android:tint="@color/neutral_600"/>
 
     </RelativeLayout>
 </com.facebook.shimmer.ShimmerFrameLayout>


### PR DESCRIPTION
This is a continuation of the work of https://github.com/wordpress-mobile/WordPress-Android/pull/9657 which adds loading skeletons for the compacted view type so that the loading skeleton does not look a totally different size to the loaded content.

General information:

This branch was taken from _onepointsixtwo/feature/master-post-filters-9184_ and should **not** be merged until after the original brach. At this point, it will need to have its base branch updated to the same base branch as that was taken from, which is _wordpress-mobile/feature/master-post-filters_

To test:

- In addition to the tests for the parent story, test that if the compact view type is selected while loading, the loading views resemble a shimmering version of the compact layout.

Update release notes:

- [X ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

![loading](https://user-images.githubusercontent.com/5874664/56680635-86ed5c00-66bf-11e9-97af-3ff07410b5ec.gif)
